### PR TITLE
use optimizer but disable yul optimizer because of big num library

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -2,6 +2,8 @@
 src = 'src'
 out = 'out'
 libs = ['lib']
-optimizer = false
+
+[profile.default.optimizer_details]
+yul = false
 
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config


### PR DESCRIPTION
this reduces the output binary by enabling the optimizer, but keeping the yul optimizer disabled to support big number library